### PR TITLE
feat: Enhance theme support and update logo paths across components

### DIFF
--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -1,4 +1,3 @@
-import { SparklesCore } from "@/components/ui/sparkles";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -8,6 +7,16 @@ interface Props {
 const Layout = ({ children }: Props) => {
   return (
     <main className="flex flex-col min-h-screen max-h-screen bg-background dark:bg-background">
+      <div
+        className={cn(
+          "absolute inset-0",
+          "[background-size:20px_20px]",
+          "[background-image:radial-gradient(#d4d4d4_1px,transparent_1px)]",
+          "dark:[background-image:radial-gradient(#404040_1px,transparent_1px)]"
+        )}
+      />
+      {/* Radial gradient for the container to give a faded look */}
+      <div className="pointer-events-none absolute inset-0 flex items-center justify-center bg-background [mask-image:radial-gradient(ellipse_at_center,transparent_20%,black)] dark:bg-background"></div>
       {/* <div className="absolute inset-0 -z-10 h-full w-full bg-background dark:bg-[radial-gradient(#393e4a_1px,transparent_2px)] bg-[radial-gradient(#dadde1_1px,transparent_2px)] [background-size:61px_61px]" /> */}
       <div className="flex-1 flex flex-col px-4 pb-4">{children}</div>
     </main>

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -15,14 +15,19 @@ import { Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
 
 const Page = () => {
-  const { setTheme } = useTheme();
+  const { theme, setTheme } = useTheme();
+  const currentTheme = theme === "system" ? setTheme : theme;
 
   return (
-    <div className="flex flex-col max-w-5xl mx-auto w-full">
+    <div className="flex flex-col max-w-5xl mx-auto w-full z-10">
       <section className="space-y-6 py-[16vh] 2xl:py-48">
         <div className="flex felx-col items-center justify-center">
           <Image
-            src="/Arccane_logo_dark.svg"
+            src={
+              currentTheme === "light" || currentTheme === "system"
+                ? "/Arccane_logo_dark.svg"
+                : "/Arccane_logo.svg"
+            }
             alt="Arccane Logo"
             width={80}
             height={80}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -48,7 +48,6 @@
   --shadow-lg: 0 1px 3px 0px hsl(0 0% 0% / 0.10), 0 4px 6px -1px hsl(0 0% 0% / 0.10);
   --shadow-xl: 0 1px 3px 0px hsl(0 0% 0% / 0.10), 0 8px 10px -1px hsl(0 0% 0% / 0.10);
   --shadow-2xl: 0 1px 3px 0px hsl(0 0% 0% / 0.25);
-  
 }
 
 .dark {
@@ -219,4 +218,3 @@
     }
   }
 }
-

--- a/src/modules/home/ui/components/projects-llist.tsx
+++ b/src/modules/home/ui/components/projects-llist.tsx
@@ -2,14 +2,17 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import { FormatDateOptions, formatDistanceToNow } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
 import { useQuery } from "@tanstack/react-query";
 
 import { useTRPC } from "@/trpc/client";
+import { useTheme } from "next-themes";
 import { Button } from "@/components/ui/button";
 
 export const ProjectsList = () => {
   const trpc = useTRPC();
+  const { theme, setTheme } = useTheme();
+  const currentTheme = theme === "system" ? setTheme : theme;
   const { data: projects } = useQuery(trpc.projects.getMany.queryOptions());
 
   if (!projects) return null;
@@ -36,7 +39,11 @@ export const ProjectsList = () => {
             >
               <div className="flex items-center gap-x-4">
                 <Image
-                  src="/Arccane_logo_dark.svg"
+                  src={
+                    currentTheme === "light" || currentTheme === "system"
+                      ? "/Arccane_logo_dark.svg"
+                      : "/Arccane_logo.svg"
+                  }
                   alt="Arccane Logo"
                   width={32}
                   height={32}

--- a/src/modules/projects/ui/components/message-card.tsx
+++ b/src/modules/projects/ui/components/message-card.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Image from "next/image";
 import { format } from "date-fns";
 import { ChevronRightIcon, Code2Icon } from "lucide-react";
@@ -5,6 +7,7 @@ import { ChevronRightIcon, Code2Icon } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Card } from "@/components/ui/card";
 import { Fragment, MessageRole, MessageType } from "@/generated/prisma";
+import { useTheme } from "next-themes";
 
 interface FragmentCardProps {
   fragment: Fragment;
@@ -57,6 +60,9 @@ const AssistantMessage = ({
   onFragmentClick,
   type,
 }: AssistantMessageProps) => {
+  const { theme, setTheme } = useTheme();
+  const currentTheme = theme === "system" ? setTheme : theme;
+
   return (
     <div
       className={cn(
@@ -68,7 +74,11 @@ const AssistantMessage = ({
     >
       <div className="flex items-center gap-2 mb-2 bg-gradient-to-r from-black/15 to-transparent dark:bg-gradient-to-r dark:from-white/20 dark:to-transparent rounded-full p-2">
         <Image
-          src="/Arccane_logo_dark.svg"
+          src={
+            currentTheme === "light" || currentTheme === "system"
+              ? "/Arccane_logo_dark.svg"
+              : "/Arccane_logo.svg"
+          }
           alt="Arccane AI Logo"
           width={20}
           height={20}

--- a/src/modules/projects/ui/components/message-loading.tsx
+++ b/src/modules/projects/ui/components/message-loading.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useTheme } from "next-themes";
 import Image from "next/image";
 import { useState, useEffect } from "react";
 
@@ -36,11 +39,18 @@ const ShimmerMessages = () => {
 };
 
 export const MessageLoading = () => {
+  const { theme, setTheme } = useTheme();
+  const currentTheme = theme === "system" ? setTheme : theme;
+
   return (
     <div className="flex flex-col group px-2 pb-4">
       <div className="flex items-center gap-2 pl-2 mb-2">
         <Image
-          src="/Arccane_logo_dark.svg"
+          src={
+            currentTheme === "light" || currentTheme === "system"
+              ? "/Arccane_logo_dark.svg"
+              : "/Arccane_logo.svg"
+          }
           alt="Arccane Logo"
           width={20}
           height={20}

--- a/src/modules/projects/ui/components/project-header.tsx
+++ b/src/modules/projects/ui/components/project-header.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import Link from "next/link";
 import Image from "next/image";
 import { useTheme } from "next-themes";
@@ -38,6 +40,7 @@ export const ProjectHeader = ({ projectId }: Props) => {
   );
 
   const { theme, setTheme } = useTheme();
+  const currentTheme = theme === "system" ? setTheme : theme;
 
   return (
     <header className="p-2 flex items-center justify-between border-b">
@@ -49,7 +52,11 @@ export const ProjectHeader = ({ projectId }: Props) => {
             className="focus-visible:ring-0 hover:bg-transparent hover:opacity-75 transition-opacity pl-2!"
           >
             <Image
-              src="/Arccane_logo_dark.svg"
+              src={
+                currentTheme === "light" || currentTheme === "system"
+                  ? "/Arccane_logo_dark.svg"
+                  : "/Arccane_logo.svg"
+              }
               alt="Arccane Logo"
               width={32}
               height={32}


### PR DESCRIPTION
This pull request introduces dynamic theme-based logo rendering across multiple components and improves the visual background of the home layout. The main focus is to ensure the correct logo is displayed for light and dark modes, and to enhance the UI background for a more polished look.

**Theme-based logo rendering:**

* Updated `ProjectsList`, `AssistantMessage`, `MessageLoading`, and `ProjectHeader` components to use the appropriate logo (`/Arccane_logo_dark.svg` for light/system theme, `/Arccane_logo.svg` for dark theme) by leveraging the `next-themes` library for theme detection. [[1]](diffhunk://#diff-d78971b07af39402bfd3452d527495acade1b4104e6c372bf1ba794d9056ff37L5-R15) [[2]](diffhunk://#diff-d78971b07af39402bfd3452d527495acade1b4104e6c372bf1ba794d9056ff37L39-R46) [[3]](diffhunk://#diff-6e563732c55218b9c8bbec3b994ec7ca58f6880b160f62fa827170f4fc714285R1-R10) [[4]](diffhunk://#diff-6e563732c55218b9c8bbec3b994ec7ca58f6880b160f62fa827170f4fc714285R63-R65) [[5]](diffhunk://#diff-6e563732c55218b9c8bbec3b994ec7ca58f6880b160f62fa827170f4fc714285L71-R81) [[6]](diffhunk://#diff-bd6306a95e5423c2ac1a72d4116c5e3daaf937ec55e96b8050d1a309c07acee6R1-R3) [[7]](diffhunk://#diff-bd6306a95e5423c2ac1a72d4116c5e3daaf937ec55e96b8050d1a309c07acee6R42-R53) [[8]](diffhunk://#diff-aaa93f889ff0d0a7fb41acb58787e9fc22c7f7bbcec4fb344640c0d2d456405bR1-R2) [[9]](diffhunk://#diff-aaa93f889ff0d0a7fb41acb58787e9fc22c7f7bbcec4fb344640c0d2d456405bR43) [[10]](diffhunk://#diff-aaa93f889ff0d0a7fb41acb58787e9fc22c7f7bbcec4fb344640c0d2d456405bL52-R59)

* Modified the main logo in the home page (`page.tsx`) to switch based on the current theme, ensuring consistent branding throughout the app.

**UI and background improvements:**

* Enhanced the home layout background by adding a subtle radial gradient and faded mask, improving the overall appearance for both light and dark modes.

**Code cleanup:**

* Removed unused imports and minor whitespace from various files for better maintainability. [[1]](diffhunk://#diff-d66da1b2249038dc5d7672bcb640b2c0d9317e6ab32b36c0e0b1f6ccb9386123L1) [[2]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L51) [[3]](diffhunk://#diff-4f206759c961f544a48464ad2ee231adc87e72593d03a0004b68c17771f7a412L222)